### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,8 @@
 #
 # docker run -i --rm -p 8081:8081 springboot/sample-demo
 ####
-FROM quay.io/eclipse/che-java11-maven:nightly
+FROM maven:3.8.1-openjdk-17-slim
 
-USER root
 WORKDIR /build
 
 # Build dependency offline to streamline build


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

@elsony If I use an openjdk mvn image, I dont have to switch to root using `USER root`.  I've just grabbed the latest openjdk mvn image from [here](https://hub.docker.com/_/maven?tab=tags&page=1&ordering=last_updated&name=openjdk)

![Screen Shot 2021-05-06 at 3 53 52 PM](https://user-images.githubusercontent.com/31771087/117357942-8e859500-ae83-11eb-9200-b61435e04d94.png)
![Screen Shot 2021-05-06 at 3 55 44 PM](https://user-images.githubusercontent.com/31771087/117357944-8f1e2b80-ae83-11eb-95c9-667c409ba9b8.png)
