### PR TITLE
Update Dockerfile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Spring Boot-DemoApplication<demo>",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "mainClass": "com.example.demo.DemoApplication",
+            "projectName": "demo",
+            "args": ""
+        }
+    ]
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 #
 # docker run -i --rm -p 8081:8081 springboot/sample-demo
 ####
-FROM maven:3.8.1-openjdk-17-slim
+FROM maven:3.8-openjdk-17-slim
 
 WORKDIR /build
 

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -15,6 +15,11 @@ public class DemoApplication {
         return "Hello World!";
     }
 
+    @RequestMapping("/test")
+    String test() {
+        return "Testing. This is an end point v2!";
+    }
+
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);
     }


### PR DESCRIPTION
**3.8.1-openjdk-17-slim** no longer exist, changing to a more **3.8-openjdk-17-slim** which appears to be always pointing to the latest of 3.8.x.